### PR TITLE
add support for sonar authorization (token or username/password)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@ release.properties
 dependency-reduced-pom.xml
 buildNumber.properties
 .mvn/timing.properties
+
+# IntelliJ
+.idea/
+*.iml


### PR DESCRIPTION
This PR adds support for basic auth with token or username/password ([SonarQube Docs - Web API Authentication](https://docs.sonarqube.org/latest/extend/web-api/)) by reading the same properties that are required by sonar plugin: `sonar.login` and `sonar.password`